### PR TITLE
Help launch script find its home when symlinked

### DIFF
--- a/package/linux/launch-umongo.sh
+++ b/package/linux/launch-umongo.sh
@@ -1,5 +1,9 @@
 #!/bin/sh
-dir=`dirname $0`
+if [[ -L $0 ]]; then
+	dir="$(dirname "$(readlink -f "$0")")"
+else
+	dir=`dirname $0`
+fi
 cd $dir
 
 if [ -z $minHeap ]; then minHeap=64; fi


### PR DESCRIPTION
dirname is not enough when the launch script is linked into e.g.
/usr/local/bin/umongo.
